### PR TITLE
Moved redundant functions in separate files

### DIFF
--- a/Resources/SEGIShaderCommon.cginc
+++ b/Resources/SEGIShaderCommon.cginc
@@ -1,0 +1,36 @@
+﻿sampler2D _MainTex;
+float4 _MainTex_ST;
+
+struct v2g
+{
+	float4 pos : SV_POSITION;
+	half4 uv : TEXCOORD0;
+	float3 normal : TEXCOORD1;
+	float angle : TEXCOORD2;
+};
+
+struct g2f
+{
+	float4 pos : SV_POSITION;
+	half4 uv : TEXCOORD0;
+	float3 normal : TEXCOORD1;
+	float angle : TEXCOORD2;
+};
+
+v2g vert(appdata_full v)
+{
+	v2g o;
+	UNITY_INITIALIZE_OUTPUT(v2g, o);
+
+	float4 vertex = v.vertex;
+
+	o.normal = UnityObjectToWorldNormal(v.normal);
+	float3 absNormal = abs(o.normal);
+
+	o.pos = vertex;
+
+	o.uv = float4(TRANSFORM_TEX(v.texcoord.xy, _MainTex), 1.0, 1.0);
+
+
+	return o;
+}

--- a/Resources/SEGIShaderCommon.cginc.meta
+++ b/Resources/SEGIShaderCommon.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a0599a52716f6f04b93ea1727cf68aa3
+timeCreated: 1507277666
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/SEGITraceScene.shader
+++ b/Resources/SEGITraceScene.shader
@@ -21,7 +21,8 @@
 				#pragma geometry geom
 				#include "UnityCG.cginc"
 				#include "SEGIUtils.cginc"
-				
+				#include "SEGIShaderCommon.cginc"
+
 				#define PI 3.14159265
 				
 				RWTexture3D<uint> RG0;
@@ -38,47 +39,12 @@
 				float4x4 SEGIVoxelViewFront;
 				float4x4 SEGIVoxelViewLeft;
 				float4x4 SEGIVoxelViewTop;
-				
-				sampler2D _MainTex;
-				float4 _MainTex_ST;
+
 				half4 _EmissionColor;
 				float _Cutoff;
 				
-				struct v2g
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
-				struct g2f
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
 				half4 _Color;
 				float SEGISecondaryOcclusionStrength;
-				
-				v2g vert(appdata_full v)
-				{
-					v2g o;
-					UNITY_INITIALIZE_OUTPUT(v2g, o);
-					
-					float4 vertex = v.vertex;
-					
-					o.normal = UnityObjectToWorldNormal(v.normal);
-					float3 absNormal = abs(o.normal);
-					
-					o.pos = vertex;
-					
-					o.uv = float4(TRANSFORM_TEX(v.texcoord.xy, _MainTex), 1.0, 1.0);
-					
-					return o;
-				}
 				
 				int SEGIVoxelResolution;
 				
@@ -90,7 +56,7 @@
 					for (i = 0; i < 3; i++)
 					{
 						p[i] = input[i];
-						p[i].pos = mul(unity_ObjectToWorld, p[i].pos);						
+						p[i].pos = mul(unity_ObjectToWorld, p[i].pos);
 					}
 					
 					float3 realNormal = float3(0.0, 0.0, 0.0);

--- a/Resources/SEGITraceScene.shader
+++ b/Resources/SEGITraceScene.shader
@@ -20,6 +20,7 @@
 				#pragma fragment frag
 				#pragma geometry geom
 				#include "UnityCG.cginc"
+				#include "SEGIUtils.cginc"
 				
 				#define PI 3.14159265
 				
@@ -246,82 +247,6 @@
 					float noiseY = saturate(frac(sin(dot(coord, float3(12.9898, 78.223, 35.2879)*2.0)) * 43758.5453));
 					
 					return float2(noiseX, noiseY);
-				}
-
-				float3 rgb2hsv(float3 c)
-				{
-					float4 k = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-					float4 p = lerp(float4(c.bg, k.wz), float4(c.gb, k.xy), step(c.b, c.g));
-					float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
-
-					float d = q.x - min(q.w, q.y);
-					float e = 1.0e-10;
-
-					return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-				}
-
-				float3 hsv2rgb(float3 c)
-				{
-					float4 k = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-					float3 p = abs(frac(c.xxx + k.xyz) * 6.0 - k.www);
-					return c.z * lerp(k.xxx, saturate(p - k.xxx), c.y);
-				}
-
-				float4 DecodeRGBAuint(uint value)
-				{
-					uint ai = value & 0x0000007F;
-					uint vi = (value / 0x00000080) & 0x000007FF;
-					uint si = (value / 0x00040000) & 0x0000007F;
-					uint hi = value / 0x02000000;
-
-					float h = float(hi) / 127.0;
-					float s = float(si) / 127.0;
-					float v = (float(vi) / 2047.0) * 10.0;
-					float a = ai * 2.0;
-
-					v = pow(v, 3.0);
-
-					float3 color = hsv2rgb(float3(h, s, v));
-
-					return float4(color.rgb, a);
-				}
-
-				uint EncodeRGBAuint(float4 color)
-				{
-					//7[HHHHHHH] 7[SSSSSSS] 11[VVVVVVVVVVV] 7[AAAAAAAA]
-					float3 hsv = rgb2hsv(color.rgb);
-					hsv.z = pow(hsv.z, 1.0 / 3.0);
-
-					uint result = 0;
-
-					uint a = min(127, uint(color.a / 2.0));
-					uint v = min(2047, uint((hsv.z / 10.0) * 2047));
-					uint s = uint(hsv.y * 127);
-					uint h = uint(hsv.x * 127);
-
-					result += a;
-					result += v * 0x00000080; // << 7
-					result += s * 0x00040000; // << 18
-					result += h * 0x02000000; // << 25
-
-					return result;
-				}
-
-				void interlockedAddFloat4(RWTexture3D<uint> destination, int3 coord, float4 value)
-				{
-					uint writeValue = EncodeRGBAuint(value);
-					uint compareValue = 0;
-					uint originalValue;
-
-					[allow_uav_condition] for (int i = 0; i < 12; i++)
-					{
-						InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
-						if (compareValue == originalValue)
-							break;
-						compareValue = originalValue;
-						float4 originalValueFloats = DecodeRGBAuint(originalValue);
-						writeValue = EncodeRGBAuint(originalValueFloats + value);
-					}
 				}
 
 				float4 frag (g2f input) : SV_TARGET

--- a/Resources/SEGITraceScene_C.shader
+++ b/Resources/SEGITraceScene_C.shader
@@ -20,7 +20,8 @@
 				#pragma fragment frag
 				#pragma geometry geom
 				#include "UnityCG.cginc"
-				
+				#include "SEGIUtils.cginc"
+
 				#define PI 3.14159265
 				
 				RWTexture3D<uint> RG0;
@@ -353,82 +354,6 @@
 					float noiseY = saturate(frac(sin(dot(coord, float3(12.9898, 78.223, 35.2879)*2.0)) * 43758.5453));
 					
 					return float2(noiseX, noiseY);
-				}
-
-				float3 rgb2hsv(float3 c)
-				{
-					float4 k = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-					float4 p = lerp(float4(c.bg, k.wz), float4(c.gb, k.xy), step(c.b, c.g));
-					float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
-
-					float d = q.x - min(q.w, q.y);
-					float e = 1.0e-10;
-
-					return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-				}
-
-				float3 hsv2rgb(float3 c)
-				{
-					float4 k = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-					float3 p = abs(frac(c.xxx + k.xyz) * 6.0 - k.www);
-					return c.z * lerp(k.xxx, saturate(p - k.xxx), c.y);
-				}
-
-				float4 DecodeRGBAuint(uint value)
-				{
-					uint ai = value & 0x0000007F;
-					uint vi = (value / 0x00000080) & 0x000007FF;
-					uint si = (value / 0x00040000) & 0x0000007F;
-					uint hi = value / 0x02000000;
-
-					float h = float(hi) / 127.0;
-					float s = float(si) / 127.0;
-					float v = (float(vi) / 2047.0) * 10.0;
-					float a = ai * 2.0;
-
-					v = pow(v, 3.0);
-
-					float3 color = hsv2rgb(float3(h, s, v));
-
-					return float4(color.rgb, a);
-				}
-
-				uint EncodeRGBAuint(float4 color)
-				{
-					//7[HHHHHHH] 7[SSSSSSS] 11[VVVVVVVVVVV] 7[AAAAAAAA]
-					float3 hsv = rgb2hsv(color.rgb);
-					hsv.z = pow(hsv.z, 1.0 / 3.0);
-
-					uint result = 0;
-
-					uint a = min(127, uint(color.a / 2.0));
-					uint v = min(2047, uint((hsv.z / 10.0) * 2047));
-					uint s = uint(hsv.y * 127);
-					uint h = uint(hsv.x * 127);
-
-					result += a;
-					result += v * 0x00000080; // << 7
-					result += s * 0x00040000; // << 18
-					result += h * 0x02000000; // << 25
-
-					return result;
-				}
-
-				void interlockedAddFloat4(RWTexture3D<uint> destination, int3 coord, float4 value)
-				{
-					uint writeValue = EncodeRGBAuint(value);
-					uint compareValue = 0;
-					uint originalValue;
-
-					[allow_uav_condition] for (int i = 0; i < 12; i++)
-					{
-						InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
-						if (compareValue == originalValue)
-							break;
-						compareValue = originalValue;
-						float4 originalValueFloats = DecodeRGBAuint(originalValue);
-						writeValue = EncodeRGBAuint(originalValueFloats + value);
-					}
 				}
 
 				float4 frag (g2f input) : SV_TARGET

--- a/Resources/SEGITraceScene_C.shader
+++ b/Resources/SEGITraceScene_C.shader
@@ -21,6 +21,7 @@
 				#pragma geometry geom
 				#include "UnityCG.cginc"
 				#include "SEGIUtils.cginc"
+				#include "SEGIShaderCommon.cginc"
 
 				#define PI 3.14159265
 				
@@ -36,48 +37,13 @@
 				float4x4 SEGIVoxelViewFront;
 				float4x4 SEGIVoxelViewLeft;
 				float4x4 SEGIVoxelViewTop;
-				
-				sampler2D _MainTex;
-				float4 _MainTex_ST;
+
 				half4 _EmissionColor;
 				float _Cutoff;
-				
-				struct v2g
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
-				struct g2f
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
+
 				half4 _Color;
 				float SEGISecondaryOcclusionStrength;
-				
-				v2g vert(appdata_full v)
-				{
-					v2g o;
-					UNITY_INITIALIZE_OUTPUT(v2g, o);
-					
-					float4 vertex = v.vertex;
-					
-					o.normal = UnityObjectToWorldNormal(v.normal);
-					float3 absNormal = abs(o.normal);
-					
-					o.pos = vertex;
-					
-					o.uv = float4(TRANSFORM_TEX(v.texcoord.xy, _MainTex), 1.0, 1.0);
-					
-					return o;
-				}
-				
+
 				int SEGIVoxelResolution;
 				
 				[maxvertexcount(3)]

--- a/Resources/SEGITransferInts.compute
+++ b/Resources/SEGITransferInts.compute
@@ -1,3 +1,5 @@
+#include "SEGIUtils.cginc"
+
 #pragma kernel CSMain
 #pragma kernel CSMain2
 
@@ -18,32 +20,6 @@ float2 IntToFloats(uint intval)
 	float value1 = f16tof32(intval);
 	float value2 = f16tof32(intval / 0x0000FFFF);
 	return float2(value1, value2);
-}
-
-float3 hsv2rgb(float3 c)
-{
-	float4 k = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-	float3 p = abs(frac(c.xxx + k.xyz) * 6.0 - k.www);
-	return c.z * lerp(k.xxx, saturate(p - k.xxx), c.y);
-}
-
-float4 DecodeRGBAuint(uint value)
-{
-	uint ai = value & 0x0000007F;
-	uint vi = (value / 0x00000080) & 0x000007FF;
-	uint si = (value / 0x00040000) & 0x0000007F;
-	uint hi = value / 0x02000000;
-
-	float h = float(hi) / 127.0;
-	float s = float(si) / 127.0;
-	float v = (float(vi) / 2047.0) * 10.0;
-	float a = ai * 2.0;
-
-	v = pow(v, 3.0);
-
-	float3 color = hsv2rgb(float3(h, s, v));
-
-	return float4(color.rgb, a);
 }
 
 [numthreads(16,16,1)]

--- a/Resources/SEGITransferInts_C.compute
+++ b/Resources/SEGITransferInts_C.compute
@@ -1,3 +1,5 @@
+#include "SEGIUtils.cginc"
+
 #pragma kernel CSMain
 #pragma kernel CSMain2
 
@@ -20,32 +22,6 @@ float2 IntToFloats(uint intval)
 	float value1 = f16tof32(intval);
 	float value2 = f16tof32(intval / 0x0000FFFF);
 	return float2(value1, value2);
-}
-
-float3 hsv2rgb(float3 c)
-{
-	float4 k = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-	float3 p = abs(frac(c.xxx + k.xyz) * 6.0 - k.www);
-	return c.z * lerp(k.xxx, saturate(p - k.xxx), c.y);
-}
-
-float4 DecodeRGBAuint(uint value)
-{
-	uint ai = value & 0x0000007F;
-	uint vi = (value / 0x00000080) & 0x000007FF;
-	uint si = (value / 0x00040000) & 0x0000007F;
-	uint hi = value / 0x02000000;
-
-	float h = float(hi) / 127.0;
-	float s = float(si) / 127.0;
-	float v = (float(vi) / 2047.0) * 10.0;
-	float a = ai * 2.0;
-
-	v = pow(v, 3.0);
-
-	float3 color = hsv2rgb(float3(h, s, v));
-
-	return float4(color.rgb, a);
 }
 
 [numthreads(16,16,1)]

--- a/Resources/SEGIUtils.cginc
+++ b/Resources/SEGIUtils.cginc
@@ -1,0 +1,94 @@
+﻿float3 rgb2hsv(float3 c)
+{
+    float4 k = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    float4 p = lerp(float4(c.bg, k.wz), float4(c.gb, k.xy), step(c.b, c.g));
+    float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+
+    return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+float3 hsv2rgb(float3 c)
+{
+    float4 k = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    float3 p = abs(frac(c.xxx + k.xyz) * 6.0 - k.www);
+    return c.z * lerp(k.xxx, saturate(p - k.xxx), c.y);
+}
+
+float4 DecodeRGBAuint(uint value)
+{
+    uint ai = value & 0x0000007F;
+    uint vi = (value / 0x00000080) & 0x000007FF;
+    uint si = (value / 0x00040000) & 0x0000007F;
+    uint hi = value / 0x02000000;
+
+    float h = float(hi) / 127.0;
+    float s = float(si) / 127.0;
+    float v = (float(vi) / 2047.0) * 10.0;
+    float a = ai * 2.0;
+
+    v = pow(v, 3.0);
+
+    float3 color = hsv2rgb(float3(h, s, v));
+
+    return float4(color.rgb, a);
+}
+
+uint EncodeRGBAuint(float4 color)
+{
+    //7[HHHHHHH] 7[SSSSSSS] 11[VVVVVVVVVVV] 7[AAAAAAAA]
+    float3 hsv = rgb2hsv(color.rgb);
+    hsv.z = pow(hsv.z, 1.0 / 3.0);
+
+    uint result = 0;
+
+    uint a = min(127, uint(color.a / 2.0));
+    uint v = min(2047, uint((hsv.z / 10.0) * 2047));
+    uint s = uint(hsv.y * 127);
+    uint h = uint(hsv.x * 127);
+
+    result += a;
+    result += v * 0x00000080; // << 7
+    result += s * 0x00040000; // << 18
+    result += h * 0x02000000; // << 25
+
+    return result;
+}
+
+void interlockedAddFloat4(RWTexture3D<uint> destination, int3 coord, float4 value)
+{
+    uint writeValue = EncodeRGBAuint(value);
+    uint compareValue = 0;
+    uint originalValue;
+
+    [allow_uav_condition]
+    while (true)
+    {
+        InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
+        if (compareValue == originalValue)
+            break;
+        compareValue = originalValue;
+        float4 originalValueFloats = DecodeRGBAuint(originalValue);
+        writeValue = EncodeRGBAuint(originalValueFloats + value);
+    }
+}
+
+void interlockedAddFloat4b(RWTexture3D<uint> destination, int3 coord, float4 value)
+{
+    uint writeValue = EncodeRGBAuint(value);
+    uint compareValue = 0;
+    uint originalValue;
+
+    [allow_uav_condition]
+    while (true)
+    {
+        InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
+        if (compareValue == originalValue)
+            break;
+        compareValue = originalValue;
+        float4 originalValueFloats = DecodeRGBAuint(originalValue);
+        writeValue = EncodeRGBAuint(originalValueFloats + value);
+    }
+}

--- a/Resources/SEGIUtils.cginc.meta
+++ b/Resources/SEGIUtils.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 314649b617899eb4cbd00ee2809aed0d
+timeCreated: 1507277666
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/SEGIVoxelizeScene.shader
+++ b/Resources/SEGIVoxelizeScene.shader
@@ -23,6 +23,7 @@
 				#pragma geometry geom
 				#include "UnityCG.cginc"
 				#include "SEGIUtils.cginc"
+				#include "SEGIShaderCommon.cginc"
 				
 				RWTexture3D<uint> RG0;
 				
@@ -31,53 +32,16 @@
 				float4x4 SEGIVoxelViewFront;
 				float4x4 SEGIVoxelViewLeft;
 				float4x4 SEGIVoxelViewTop;
-				
-				sampler2D _MainTex;
+
 				sampler2D _EmissionMap;
 				float _Cutoff;
-				float4 _MainTex_ST;
 				half4 _EmissionColor;
 
 				float SEGISecondaryBounceGain;
 				
 				float _BlockerValue;
 				
-				
-				struct v2g
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
-				struct g2f
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
 				half4 _Color;
-				
-				v2g vert(appdata_full v)
-				{
-					v2g o;
-					UNITY_INITIALIZE_OUTPUT(v2g, o);
-					
-					float4 vertex = v.vertex;
-					
-					o.normal = UnityObjectToWorldNormal(v.normal);
-					float3 absNormal = abs(o.normal);
-					
-					o.pos = vertex;
-					
-					o.uv = float4(TRANSFORM_TEX(v.texcoord.xy, _MainTex), 1.0, 1.0);
-					
-					
-					return o;
-				}
 				
 				int SEGIVoxelResolution;
 				
@@ -89,7 +53,7 @@
 					for (i = 0; i < 3; i++)
 					{
 						p[i] = input[i];
-						p[i].pos = mul(unity_ObjectToWorld, p[i].pos);						
+						p[i].pos = mul(unity_ObjectToWorld, p[i].pos);
 					}
 					
 

--- a/Resources/SEGIVoxelizeScene.shader
+++ b/Resources/SEGIVoxelizeScene.shader
@@ -22,6 +22,7 @@
 				#pragma fragment frag
 				#pragma geometry geom
 				#include "UnityCG.cginc"
+				#include "SEGIUtils.cginc"
 				
 				RWTexture3D<uint> RG0;
 				
@@ -153,101 +154,6 @@
 					triStream.Append(p[0]);
 					triStream.Append(p[1]);
 					triStream.Append(p[2]);
-				}
-
-				float3 rgb2hsv(float3 c)
-				{
-					float4 k = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-					float4 p = lerp(float4(c.bg, k.wz), float4(c.gb, k.xy), step(c.b, c.g));
-					float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
-
-					float d = q.x - min(q.w, q.y);
-					float e = 1.0e-10;
-
-					return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-				}
-
-				float3 hsv2rgb(float3 c)
-				{
-					float4 k = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-					float3 p = abs(frac(c.xxx + k.xyz) * 6.0 - k.www);
-					return c.z * lerp(k.xxx, saturate(p - k.xxx), c.y);
-				}
-
-				float4 DecodeRGBAuint(uint value)
-				{
-					uint ai = value & 0x0000007F;
-					uint vi = (value / 0x00000080) & 0x000007FF;
-					uint si = (value / 0x00040000) & 0x0000007F;
-					uint hi = value / 0x02000000;
-
-					float h = float(hi) / 127.0;
-					float s = float(si) / 127.0;
-					float v = (float(vi) / 2047.0) * 10.0;
-					float a = ai * 2.0;
-
-					v = pow(v, 3.0);
-
-					float3 color = hsv2rgb(float3(h, s, v));
-
-					return float4(color.rgb, a);
-				}
-
-				uint EncodeRGBAuint(float4 color)
-				{
-					//7[HHHHHHH] 7[SSSSSSS] 11[VVVVVVVVVVV] 7[AAAAAAAA]
-					float3 hsv = rgb2hsv(color.rgb);
-					hsv.z = pow(hsv.z, 1.0 / 3.0);
-
-					uint result = 0;
-
-					uint a = min(127, uint(color.a / 2.0));
-					uint v = min(2047, uint((hsv.z / 10.0) * 2047));
-					uint s = uint(hsv.y * 127);
-					uint h = uint(hsv.x * 127);
-
-					result += a;
-					result += v * 0x00000080; // << 7
-					result += s * 0x00040000; // << 18
-					result += h * 0x02000000; // << 25
-
-					return result;
-				}
-
-				void interlockedAddFloat4(RWTexture3D<uint> destination, int3 coord, float4 value)
-				{
-					uint writeValue = EncodeRGBAuint(value);
-					uint compareValue = 0;
-					uint originalValue;
-
-					[allow_uav_condition]
-					while (true)
-					{
-						InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
-						if (compareValue == originalValue)
-							break;
-						compareValue = originalValue;
-						float4 originalValueFloats = DecodeRGBAuint(originalValue);
-						writeValue = EncodeRGBAuint(originalValueFloats + value);
-					}
-				}
-
-				void interlockedAddFloat4b(RWTexture3D<uint> destination, int3 coord, float4 value)
-				{
-					uint writeValue = EncodeRGBAuint(value);
-					uint compareValue = 0;
-					uint originalValue;
-
-					[allow_uav_condition]
-					while (true)
-					{
-						InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
-						if (compareValue == originalValue)
-							break;
-						compareValue = originalValue;
-						float4 originalValueFloats = DecodeRGBAuint(originalValue);
-						writeValue = EncodeRGBAuint(originalValueFloats + value);
-					}
 				}
 
 				float4x4 SEGIVoxelToGIProjection;

--- a/Resources/SEGIVoxelizeScene_C.shader
+++ b/Resources/SEGIVoxelizeScene_C.shader
@@ -23,7 +23,8 @@
 				#pragma geometry geom
 				#include "UnityCG.cginc"
 				#include "SEGIUtils.cginc"
-				
+				#include "SEGIShaderCommon.cginc"
+
 				RWTexture3D<uint> RG0;
 				
 				int LayerToVisualize;
@@ -31,54 +32,16 @@
 				float4x4 SEGIVoxelViewFront;
 				float4x4 SEGIVoxelViewLeft;
 				float4x4 SEGIVoxelViewTop;
-				
-				sampler2D _MainTex;
+
+				half4 _Color;
 				sampler2D _EmissionMap;
 				float _Cutoff;
-				float4 _MainTex_ST;
 				half4 _EmissionColor;
 
 				float SEGISecondaryBounceGain;
 				
 				float _BlockerValue;
-				
-				
-				struct v2g
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
-				struct g2f
-				{
-					float4 pos : SV_POSITION;
-					half4 uv : TEXCOORD0;
-					float3 normal : TEXCOORD1;
-					float angle : TEXCOORD2;
-				};
-				
-				half4 _Color;
-				
-				v2g vert(appdata_full v)
-				{
-					v2g o;
-					UNITY_INITIALIZE_OUTPUT(v2g, o);
-					
-					float4 vertex = v.vertex;
-					
-					o.normal = UnityObjectToWorldNormal(v.normal);
-					float3 absNormal = abs(o.normal);
-					
-					o.pos = vertex;
-					
-					o.uv = float4(TRANSFORM_TEX(v.texcoord.xy, _MainTex), 1.0, 1.0);
-					
-					
-					return o;
-				}
-				
+
 				int SEGIVoxelResolution;
 				int SEGIVoxelAA;
 				#define VoxelResolution (SEGIVoxelResolution * (1 + SEGIVoxelAA))

--- a/Resources/SEGIVoxelizeScene_C.shader
+++ b/Resources/SEGIVoxelizeScene_C.shader
@@ -22,6 +22,7 @@
 				#pragma fragment frag
 				#pragma geometry geom
 				#include "UnityCG.cginc"
+				#include "SEGIUtils.cginc"
 				
 				RWTexture3D<uint> RG0;
 				
@@ -162,101 +163,6 @@
 					triStream.Append(p[0]);
 					triStream.Append(p[1]);
 					triStream.Append(p[2]);
-				}
-
-				float3 rgb2hsv(float3 c)
-				{
-					float4 k = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-					float4 p = lerp(float4(c.bg, k.wz), float4(c.gb, k.xy), step(c.b, c.g));
-					float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
-
-					float d = q.x - min(q.w, q.y);
-					float e = 1.0e-10;
-
-					return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-				}
-
-				float3 hsv2rgb(float3 c)
-				{
-					float4 k = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-					float3 p = abs(frac(c.xxx + k.xyz) * 6.0 - k.www);
-					return c.z * lerp(k.xxx, saturate(p - k.xxx), c.y);
-				}
-
-				float4 DecodeRGBAuint(uint value)
-				{
-					uint ai = value & 0x0000007F;
-					uint vi = (value / 0x00000080) & 0x000007FF;
-					uint si = (value / 0x00040000) & 0x0000007F;
-					uint hi = value / 0x02000000;
-
-					float h = float(hi) / 127.0;
-					float s = float(si) / 127.0;
-					float v = (float(vi) / 2047.0) * 10.0;
-					float a = ai * 2.0;
-
-					v = pow(v, 3.0);
-
-					float3 color = hsv2rgb(float3(h, s, v));
-
-					return float4(color.rgb, a);
-				}
-
-				uint EncodeRGBAuint(float4 color)
-				{
-					//7[HHHHHHH] 7[SSSSSSS] 11[VVVVVVVVVVV] 7[AAAAAAAA]
-					float3 hsv = rgb2hsv(color.rgb);
-					hsv.z = pow(hsv.z, 1.0 / 3.0);
-
-					uint result = 0;
-
-					uint a = min(127, uint(color.a / 2.0));
-					uint v = min(2047, uint((hsv.z / 10.0) * 2047));
-					uint s = uint(hsv.y * 127);
-					uint h = uint(hsv.x * 127);
-
-					result += a;
-					result += v * 0x00000080; // << 7
-					result += s * 0x00040000; // << 18
-					result += h * 0x02000000; // << 25
-
-					return result;
-				}
-
-				void interlockedAddFloat4(RWTexture3D<uint> destination, int3 coord, float4 value)
-				{
-					uint writeValue = EncodeRGBAuint(value);
-					uint compareValue = 0;
-					uint originalValue;
-
-					[allow_uav_condition]
-					while (true)
-					{
-						InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
-						if (compareValue == originalValue)
-							break;
-						compareValue = originalValue;
-						float4 originalValueFloats = DecodeRGBAuint(originalValue);
-						writeValue = EncodeRGBAuint(originalValueFloats + value);
-					}
-				}
-
-				void interlockedAddFloat4b(RWTexture3D<uint> destination, int3 coord, float4 value)
-				{
-					uint writeValue = EncodeRGBAuint(value);
-					uint compareValue = 0;
-					uint originalValue;
-
-					[allow_uav_condition]
-					while (true)
-					{
-						InterlockedCompareExchange(destination[coord], compareValue, writeValue, originalValue);
-						if (compareValue == originalValue)
-							break;
-						compareValue = originalValue;
-						float4 originalValueFloats = DecodeRGBAuint(originalValue);
-						writeValue = EncodeRGBAuint(originalValueFloats + value);
-					}
 				}
 
 				float4x4 SEGIVoxelToGIProjection;


### PR DESCRIPTION
Hi,
I noticed a few redundant bits in the Voxelization/Tracing shaders, for both the standard and cascaded versions, so I refactored those into separate files.

Changes:
- utility functions (rgb <-> hsv, rgba encode/decode, interlocked add) moved to SEGIUtils.cginc
- shader structs and vertex function moved to SEGIShaderCommon.cginc

This makes shaders significantly shorter.
